### PR TITLE
Fixes incorrect usage of HTTPie in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ the best current answer is as well as whether it is deciding to buzz on the
 answer.
 
 ```bash
-$ http --form POST http://0.0.0.0:4861/api/1.0/quizbowl/act text='Name the the inventor of general relativity and the photoelectric effect'
+$ http POST http://0.0.0.0:4861/api/1.0/quizbowl/act text='Name the the inventor of general relativity and the photoelectric effect'
 HTTP/1.0 200 OK
 Content-Length: 41
 Content-Type: application/json
@@ -122,7 +122,7 @@ docker-compose up
 And then the `httpie` command from before:
 
 ```bash
-$ http --form POST http://0.0.0.0:4861/api/1.0/quizbowl/act text='Name the the inventor of general relativity and the photoelectric effect'
+$ http POST http://0.0.0.0:4861/api/1.0/quizbowl/act text='Name the the inventor of general relativity and the photoelectric effect'
 HTTP/1.0 200 OK
 Content-Length: 41
 Content-Type: application/json


### PR DESCRIPTION
According to HTTPie docs (https://httpie.org/doc#request-items) the `--form` argument forces the request to use form encoding rather than JSON encoding.  This causes an error in the codebase as the Flask app is expecting JSON.  This PR removes references to `--form` in the HTTPie examples.