### PR TITLE
data file in docker-compose.yml changed to non-paragraph version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       "--hostname", "qb",
       "--norun-web",
       "--char_step_size", "60",
-      "data/qanta.dev.paragraphs.2018.04.18.json"
+      "data/qanta.dev.2018.04.18.json"
     ]
     depends_on:
       - "qb"


### PR DESCRIPTION
The data file being pointed to currently is the paragraph one, which would necessitate downloading data with --retrieve paragraphs option (for tfidf baseline), and that data is huge (esp. for a student to download). So, probably just the non-paragraph version as the default is better? 
Pranav